### PR TITLE
Add user profile settings page

### DIFF
--- a/backend/app/api/main.go
+++ b/backend/app/api/main.go
@@ -26,6 +26,7 @@ import (
 )
 
 const Issuer = "Neskuchka"
+const prefixApi = "/api/v1"
 
 // Api is an API server
 type Api struct {
@@ -107,7 +108,7 @@ func (api *Api) Handler() *chi.Mux {
 	})
 
 	// api routes
-	router.Route("/api/v1", func(r chi.Router) {
+	router.Route(prefixApi, func(r chi.Router) {
 		r.Use(httprate.LimitByIP(60, time.Minute))
 		r.Use(chiMW.Timeout(10 * time.Second))
 
@@ -141,17 +142,28 @@ func (api *Api) addAuthRoutes(router chi.Router, session *session.Manager) {
 
 // addUserRoutes is adding user routes
 func (api *Api) addUserRoutes(router chi.Router, session *session.Manager) {
+	avatarURLFunc := func(userID domain.UserID) string {
+		return fmt.Sprintf("%s/user/%s/avatar", prefixApi, string(userID))
+	}
+
 	h := api_user.NewService(api.DataStore, api_user.Opts{
 		Logger:        log.Logger,
 		AvatarStorage: api.AvatarStorage,
+		AvatarURLFunc: avatarURLFunc,
 	})
 
 	router.Route("/user", func(r chi.Router) {
-		r.Use(session.Authenticator(httpx.RenderUnauthorized))
+		r.Route("/me", func(r chi.Router) {
+			r.Use(session.Authenticator(httpx.RenderUnauthorized))
 
-		r.Get("/me", h.Me)
-		r.Get("/me/avatar", h.Avatar)
-		r.Post("/me/avatar", h.UploadAvatar)
+			r.Get("/", h.Me)
+			r.Get("/avatar", h.MyAvatar)
+			r.Post("/avatar", h.UploadAvatar)
+		})
+
+		r.Route("/{id}", func(r chi.Router) {
+			r.Get("/avatar", h.UserAvatar)
+		})
 	})
 }
 

--- a/backend/app/api/main.go
+++ b/backend/app/api/main.go
@@ -157,8 +157,11 @@ func (api *Api) addUserRoutes(router chi.Router, session *session.Manager) {
 			r.Use(session.Authenticator(httpx.RenderUnauthorized))
 
 			r.Get("/", h.Me)
+			r.Get("/settings", h.GetSettings)
+			r.Put("/settings", h.UpdateSettings)
 			r.Get("/avatar", h.MyAvatar)
 			r.Post("/avatar", h.UploadAvatar)
+			r.Delete("/avatar", h.DeleteAvatar)
 		})
 
 		r.Route("/{id}", func(r chi.Router) {

--- a/backend/app/api/main.go
+++ b/backend/app/api/main.go
@@ -157,11 +157,13 @@ func (api *Api) addUserRoutes(router chi.Router, session *session.Manager) {
 			r.Use(session.Authenticator(httpx.RenderUnauthorized))
 
 			r.Get("/", h.Me)
-			r.Get("/settings", h.GetSettings)
-			r.Put("/settings", h.UpdateSettings)
+
 			r.Get("/avatar", h.MyAvatar)
 			r.Post("/avatar", h.UploadAvatar)
 			r.Delete("/avatar", h.DeleteAvatar)
+
+			r.Get("/settings", h.GetSettings)
+			r.Put("/settings", h.UpdateSettings)
 		})
 
 		r.Route("/{id}", func(r chi.Router) {

--- a/backend/app/api/main_test.go
+++ b/backend/app/api/main_test.go
@@ -31,6 +31,7 @@ type TestApp struct {
 	DB            *db.Engine
 	DataStorage   *datastorage.Storage
 	AvatarStorage *avatarstorage.Storage
+	AvatarURLFunc func(domain.UserID) string
 	Store         *domain.Store
 
 	SessionManager *session.Manager
@@ -65,7 +66,7 @@ func NewTestApp(t *testing.T) *TestApp {
 		Secret:    app.Secret,
 		DataStore: app.Store,
 
-		AvatarStorage: avatarstorage.New(engine, zerolog.Nop()),
+		AvatarStorage: app.AvatarStorage,
 
 		WebFS: fstest.MapFS{
 			"web/index.html": &fstest.MapFile{Data: []byte("<html>test</html>")},

--- a/backend/app/api/main_test.go
+++ b/backend/app/api/main_test.go
@@ -31,7 +31,6 @@ type TestApp struct {
 	DB            *db.Engine
 	DataStorage   *datastorage.Storage
 	AvatarStorage *avatarstorage.Storage
-	AvatarURLFunc func(domain.UserID) string
 	Store         *domain.Store
 
 	SessionManager *session.Manager
@@ -142,8 +141,12 @@ func WithMultipartFile(fieldName, fileName, contentType string, data []byte) Req
 	}
 }
 
-func (app *TestApp) DoRequest(t *testing.T, req *http.Request, opts ...RequestOption) *http.Response {
+func (app *TestApp) DoRequest(t *testing.T, method string, path string, opts ...RequestOption) *http.Response {
 	t.Helper()
+
+	url := app.Server.URL + path
+	req, err := http.NewRequest(method, url, nil)
+	require.NoError(t, err)
 
 	for _, patch := range opts {
 		patch(req)
@@ -162,41 +165,25 @@ func (app *TestApp) DoRequest(t *testing.T, req *http.Request, opts ...RequestOp
 func (app *TestApp) GET(t *testing.T, path string, opts ...RequestOption) *http.Response {
 	t.Helper()
 
-	url := app.Server.URL + path
-	req, err := http.NewRequest("GET", url, nil)
-	require.NoError(t, err)
-
-	return app.DoRequest(t, req, opts...)
+	return app.DoRequest(t, "GET", path, opts...)
 }
 
 func (app *TestApp) POST(t *testing.T, path string, opts ...RequestOption) *http.Response {
 	t.Helper()
 
-	url := app.Server.URL + path
-	req, err := http.NewRequest("POST", url, nil)
-	require.NoError(t, err)
-
-	return app.DoRequest(t, req, opts...)
+	return app.DoRequest(t, "POST", path, opts...)
 }
 
 func (app *TestApp) PUT(t *testing.T, path string, opts ...RequestOption) *http.Response {
 	t.Helper()
 
-	url := app.Server.URL + path
-	req, err := http.NewRequest("PUT", url, nil)
-	require.NoError(t, err)
-
-	return app.DoRequest(t, req, opts...)
+	return app.DoRequest(t, "PUT", path, opts...)
 }
 
 func (app *TestApp) DELETE(t *testing.T, path string, opts ...RequestOption) *http.Response {
 	t.Helper()
 
-	url := app.Server.URL + path
-	req, err := http.NewRequest("DELETE", url, nil)
-	require.NoError(t, err)
-
-	return app.DoRequest(t, req, opts...)
+	return app.DoRequest(t, "DELETE", path, opts...)
 }
 
 // ReadBody reads the body of a response and returns it as a string

--- a/backend/app/api/main_test.go
+++ b/backend/app/api/main_test.go
@@ -109,6 +109,17 @@ func WithBody(body io.Reader) RequestOption {
 	}
 }
 
+func WithJSON(data any) RequestOption {
+	return func(r *http.Request) {
+		buf, err := json.Marshal(data)
+		if err != nil {
+			panic(err)
+		}
+		r.Body = io.NopCloser(bytes.NewReader(buf))
+		r.Header.Set("Content-Type", "application/json")
+	}
+}
+
 func WithMultipartFile(fieldName, fileName, contentType string, data []byte) RequestOption {
 	return func(r *http.Request) {
 		var buf bytes.Buffer
@@ -163,6 +174,26 @@ func (app *TestApp) POST(t *testing.T, path string, opts ...RequestOption) *http
 
 	url := app.Server.URL + path
 	req, err := http.NewRequest("POST", url, nil)
+	require.NoError(t, err)
+
+	return app.DoRequest(t, req, opts...)
+}
+
+func (app *TestApp) PUT(t *testing.T, path string, opts ...RequestOption) *http.Response {
+	t.Helper()
+
+	url := app.Server.URL + path
+	req, err := http.NewRequest("PUT", url, nil)
+	require.NoError(t, err)
+
+	return app.DoRequest(t, req, opts...)
+}
+
+func (app *TestApp) DELETE(t *testing.T, path string, opts ...RequestOption) *http.Response {
+	t.Helper()
+
+	url := app.Server.URL + path
+	req, err := http.NewRequest("DELETE", url, nil)
 	require.NoError(t, err)
 
 	return app.DoRequest(t, req, opts...)

--- a/backend/app/api/user/avatar.go
+++ b/backend/app/api/user/avatar.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/healthy-heroes/neskuchka/backend/app/api/httpx"
 	"github.com/healthy-heroes/neskuchka/backend/app/domain"
 	"github.com/healthy-heroes/neskuchka/backend/app/internal/session"
@@ -20,9 +22,7 @@ var allowedMimeTypes = []string{
 	"image/webp",
 }
 
-func (s *Service) Avatar(w http.ResponseWriter, r *http.Request) {
-	id := domain.UserID(session.MustGetUserID(r))
-
+func (s *Service) avatar(w http.ResponseWriter, r *http.Request, id domain.UserID) {
 	avatar, err := s.avatarStorage.Get(r.Context(), id)
 	if err != nil {
 		httpx.RenderDomainError(w, s.logger, err, "failed to get avatar")
@@ -33,6 +33,18 @@ func (s *Service) Avatar(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", strconv.Itoa(len(avatar.Data)))
 	w.Header().Set("Cache-Control", "private, max-age=86400")
 	w.Write(avatar.Data)
+}
+
+func (s *Service) MyAvatar(w http.ResponseWriter, r *http.Request) {
+	id := domain.UserID(session.MustGetUserID(r))
+
+	s.avatar(w, r, id)
+}
+
+func (s *Service) UserAvatar(w http.ResponseWriter, r *http.Request) {
+	id := domain.UserID(chi.URLParam(r, "id"))
+
+	s.avatar(w, r, id)
 }
 
 func (s *Service) UploadAvatar(w http.ResponseWriter, r *http.Request) {

--- a/backend/app/api/user/avatar.go
+++ b/backend/app/api/user/avatar.go
@@ -47,6 +47,18 @@ func (s *Service) UserAvatar(w http.ResponseWriter, r *http.Request) {
 	s.avatar(w, r, id)
 }
 
+func (s *Service) DeleteAvatar(w http.ResponseWriter, r *http.Request) {
+	id := domain.UserID(session.MustGetUserID(r))
+
+	err := s.avatarStorage.Delete(r.Context(), id)
+	if err != nil {
+		httpx.RenderDomainError(w, s.logger, err, "failed to delete avatar")
+		return
+	}
+
+	httpx.Render(w, nil)
+}
+
 func (s *Service) UploadAvatar(w http.ResponseWriter, r *http.Request) {
 	id := domain.UserID(session.MustGetUserID(r))
 

--- a/backend/app/api/user/schema.go
+++ b/backend/app/api/user/schema.go
@@ -2,6 +2,8 @@ package api_user
 
 import (
 	validation "github.com/go-ozzo/ozzo-validation/v4"
+
+	"github.com/healthy-heroes/neskuchka/backend/app/domain"
 )
 
 // UserSchema is the schema for data about logged user
@@ -15,6 +17,13 @@ type UserSchema struct {
 type SettingsSchema struct {
 	Name  string
 	Email string
+}
+
+func MakeSettingsSchema(user domain.User) SettingsSchema {
+	return SettingsSchema{
+		Name:  user.Name,
+		Email: string(user.Email),
+	}
 }
 
 // UpdateSettingsSchema is the schema for updating user settings

--- a/backend/app/api/user/schema.go
+++ b/backend/app/api/user/schema.go
@@ -13,9 +13,8 @@ type UserSchema struct {
 
 // SettingsSchema is the schema for the user settings page
 type SettingsSchema struct {
-	Name   string
-	Email  string
-	Avatar string `json:",omitempty"`
+	Name  string
+	Email string
 }
 
 // UpdateSettingsSchema is the schema for updating user settings

--- a/backend/app/api/user/schema.go
+++ b/backend/app/api/user/schema.go
@@ -2,6 +2,7 @@ package api_user
 
 // UserSchema is the schema for data about logged user
 type UserSchema struct {
-	ID   string
-	Name string
+	ID     string
+	Name   string
+	Avatar string `json:",omitempty"`
 }

--- a/backend/app/api/user/schema.go
+++ b/backend/app/api/user/schema.go
@@ -1,8 +1,30 @@
 package api_user
 
+import (
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
 // UserSchema is the schema for data about logged user
 type UserSchema struct {
 	ID     string
 	Name   string
 	Avatar string `json:",omitempty"`
+}
+
+// SettingsSchema is the schema for the user settings page
+type SettingsSchema struct {
+	Name   string
+	Email  string
+	Avatar string `json:",omitempty"`
+}
+
+// UpdateSettingsSchema is the schema for updating user settings
+type UpdateSettingsSchema struct {
+	Name string `json:"Name"`
+}
+
+func (s UpdateSettingsSchema) Validate() error {
+	return validation.ValidateStruct(&s,
+		validation.Field(&s.Name, validation.Required, validation.Length(1, 100)),
+	)
 }

--- a/backend/app/api/user/service.go
+++ b/backend/app/api/user/service.go
@@ -11,19 +11,24 @@ import (
 type AvatarStorage interface {
 	Get(context.Context, domain.UserID) (domain.Avatar, error)
 	Save(context.Context, domain.UserID, domain.Avatar) error
+	Exists(context.Context, domain.UserID) (bool, error)
 }
+
+type AvatarURLFunc func(domain.UserID) string
 
 // Service is a service for user API
 type Service struct {
 	logger        zerolog.Logger
 	dataStore     *domain.Store
 	avatarStorage AvatarStorage
+	avatarURLFunc AvatarURLFunc
 }
 
 type Opts struct {
 	Logger zerolog.Logger
 
 	AvatarStorage AvatarStorage
+	AvatarURLFunc AvatarURLFunc
 }
 
 func NewService(dataStore *domain.Store, opts Opts) *Service {
@@ -31,5 +36,6 @@ func NewService(dataStore *domain.Store, opts Opts) *Service {
 		logger:        opts.Logger,
 		dataStore:     dataStore,
 		avatarStorage: opts.AvatarStorage,
+		avatarURLFunc: opts.AvatarURLFunc,
 	}
 }

--- a/backend/app/api/user/service.go
+++ b/backend/app/api/user/service.go
@@ -11,6 +11,7 @@ import (
 type AvatarStorage interface {
 	Get(context.Context, domain.UserID) (domain.Avatar, error)
 	Save(context.Context, domain.UserID, domain.Avatar) error
+	Delete(context.Context, domain.UserID) error
 	Exists(context.Context, domain.UserID) (bool, error)
 }
 

--- a/backend/app/api/user/user.go
+++ b/backend/app/api/user/user.go
@@ -18,8 +18,20 @@ func (s *Service) Me(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpx.Render(w, UserSchema{
+	response := UserSchema{
 		ID:   string(user.ID),
 		Name: user.Name,
-	})
+	}
+
+	exists, err := s.avatarStorage.Exists(r.Context(), user.ID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to check if avatar exists")
+		exists = false
+	}
+
+	if exists {
+		response.Avatar = s.avatarURLFunc(user.ID)
+	}
+
+	httpx.Render(w, response)
 }

--- a/backend/app/api/user/user.go
+++ b/backend/app/api/user/user.go
@@ -1,7 +1,6 @@
 package api_user
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/healthy-heroes/neskuchka/backend/app/api/httpx"
@@ -47,7 +46,7 @@ func (s *Service) GetSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpx.Render(w, s.toSettingsSchema(r.Context(), user))
+	httpx.Render(w, toSettingsSchema(user))
 }
 
 func (s *Service) UpdateSettings(w http.ResponseWriter, r *http.Request) {
@@ -67,24 +66,12 @@ func (s *Service) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpx.Render(w, s.toSettingsSchema(r.Context(), user))
+	httpx.Render(w, toSettingsSchema(user))
 }
 
-func (s *Service) toSettingsSchema(ctx context.Context, user domain.User) SettingsSchema {
-	response := SettingsSchema{
+func toSettingsSchema(user domain.User) SettingsSchema {
+	return SettingsSchema{
 		Name:  user.Name,
 		Email: string(user.Email),
 	}
-
-	exists, err := s.avatarStorage.Exists(ctx, user.ID)
-	if err != nil {
-		s.logger.Error().Err(err).Msg("failed to check if avatar exists")
-		exists = false
-	}
-
-	if exists {
-		response.Avatar = s.avatarURLFunc(user.ID)
-	}
-
-	return response
 }

--- a/backend/app/api/user/user.go
+++ b/backend/app/api/user/user.go
@@ -46,7 +46,7 @@ func (s *Service) GetSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpx.Render(w, toSettingsSchema(user))
+	httpx.Render(w, MakeSettingsSchema(user))
 }
 
 func (s *Service) UpdateSettings(w http.ResponseWriter, r *http.Request) {
@@ -66,12 +66,5 @@ func (s *Service) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	httpx.Render(w, toSettingsSchema(user))
-}
-
-func toSettingsSchema(user domain.User) SettingsSchema {
-	return SettingsSchema{
-		Name:  user.Name,
-		Email: string(user.Email),
-	}
+	httpx.Render(w, MakeSettingsSchema(user))
 }

--- a/backend/app/api/user/user.go
+++ b/backend/app/api/user/user.go
@@ -1,6 +1,7 @@
 package api_user
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/healthy-heroes/neskuchka/backend/app/api/httpx"
@@ -34,4 +35,56 @@ func (s *Service) Me(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httpx.Render(w, response)
+}
+
+func (s *Service) GetSettings(w http.ResponseWriter, r *http.Request) {
+	id := domain.UserID(session.MustGetUserID(r))
+
+	user, err := s.dataStore.GetUser(r.Context(), id)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to get user")
+		httpx.RenderUnauthorized(w)
+		return
+	}
+
+	httpx.Render(w, s.toSettingsSchema(r.Context(), user))
+}
+
+func (s *Service) UpdateSettings(w http.ResponseWriter, r *http.Request) {
+	id := domain.UserID(session.MustGetUserID(r))
+
+	body, ok := httpx.ParseAndValidateBody[UpdateSettingsSchema](w, r, s.logger)
+	if !ok {
+		return
+	}
+
+	user, err := s.dataStore.UpdateUser(r.Context(), domain.User{
+		ID:   id,
+		Name: body.Name,
+	})
+	if err != nil {
+		httpx.RenderDomainError(w, s.logger, err, "failed to update user")
+		return
+	}
+
+	httpx.Render(w, s.toSettingsSchema(r.Context(), user))
+}
+
+func (s *Service) toSettingsSchema(ctx context.Context, user domain.User) SettingsSchema {
+	response := SettingsSchema{
+		Name:  user.Name,
+		Email: string(user.Email),
+	}
+
+	exists, err := s.avatarStorage.Exists(ctx, user.ID)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("failed to check if avatar exists")
+		exists = false
+	}
+
+	if exists {
+		response.Avatar = s.avatarURLFunc(user.ID)
+	}
+
+	return response
 }

--- a/backend/app/api/user_test.go
+++ b/backend/app/api/user_test.go
@@ -2,26 +2,25 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 	"image"
 	"image/jpeg"
 	"image/png"
 	"net/http"
 	"testing"
 
-	"github.com/healthy-heroes/neskuchka/backend/app/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/healthy-heroes/neskuchka/backend/app/domain"
+	"github.com/healthy-heroes/neskuchka/backend/app/internal/testutil"
 )
 
 func Test_ApiUserService_User(t *testing.T) {
 	app := NewTestApp(t)
 
 	t.Run("should returns current user", func(t *testing.T) {
-		user, err := app.DataStorage.CreateUser(t.Context(), domain.User{
-			ID:    domain.NewUserID(),
-			Name:  "Test name",
-			Email: "test@example.com",
-		})
+		user, err := app.DataStorage.CreateUser(t.Context(), testutil.CreateUser())
 		require.NoError(t, err)
 
 		resp := app.GET(t, "/api/v1/user/me", WithCookie(app.LoginAs(t, user.ID)))
@@ -37,6 +36,36 @@ func Test_ApiUserService_User(t *testing.T) {
 		assert.Equal(t, userResp{string(user.ID), user.Name}, data)
 	})
 
+	t.Run("should return avatar url if avatar exists", func(t *testing.T) {
+		user, err := app.DataStorage.CreateUser(t.Context(), testutil.CreateUser())
+		require.NoError(t, err)
+
+		err = app.AvatarStorage.Save(t.Context(), user.ID, domain.Avatar{
+			MimeType: "image/png",
+			Data:     []byte("test"),
+		})
+		require.NoError(t, err)
+
+		resp := app.GET(t, "/api/v1/user/me", WithCookie(app.LoginAs(t, user.ID)))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		type userResp struct {
+			ID     string
+			Name   string
+			Avatar string
+		}
+		data := ReadJSON[userResp](t, resp)
+
+		assert.Equal(t,
+			userResp{
+				string(user.ID),
+				user.Name,
+				fmt.Sprintf("%s/user/%s/avatar", prefixApi, string(user.ID)),
+			},
+			data,
+		)
+	})
+
 	t.Run("should return 401 if user is not logged in", func(t *testing.T) {
 		resp := app.GET(t, "/api/v1/user/me")
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
@@ -48,7 +77,7 @@ func Test_ApiUserService_User(t *testing.T) {
 	})
 }
 
-func Test_ApiUserService_Avatar(t *testing.T) {
+func Test_ApiUserService_MyAvatar(t *testing.T) {
 	app := NewTestApp(t)
 
 	t.Run("should return avatar bytes", func(t *testing.T) {
@@ -69,6 +98,29 @@ func Test_ApiUserService_Avatar(t *testing.T) {
 	t.Run("should return 401 if user is not logged in", func(t *testing.T) {
 		resp := app.GET(t, "/api/v1/user/me/avatar")
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+func Test_ApiUserService_UserAvatar(t *testing.T) {
+	app := NewTestApp(t)
+
+	t.Run("should return avatar bytes", func(t *testing.T) {
+		userID := domain.NewUserID()
+		err := app.AvatarStorage.Save(t.Context(), userID, domain.Avatar{
+			MimeType: "image/jpeg",
+			Data:     []byte("test"),
+		})
+		require.NoError(t, err)
+
+		resp := app.GET(t, fmt.Sprintf("/api/v1/user/%s/avatar", string(userID)))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "image/jpeg", resp.Header.Get("Content-Type"))
+		assert.Equal(t, "test", ReadBody(t, resp))
+	})
+
+	t.Run("should return 404 if avatar does not exist", func(t *testing.T) {
+		resp := app.GET(t, "/api/v1/user/1/avatar")
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	})
 }
 

--- a/backend/app/api/user_test.go
+++ b/backend/app/api/user_test.go
@@ -96,33 +96,6 @@ func Test_ApiUserService_GetSettings(t *testing.T) {
 		assert.Equal(t, settingsResp{user.Name, string(user.Email)}, data)
 	})
 
-	t.Run("should return avatar url if avatar exists", func(t *testing.T) {
-		user, err := app.DataStorage.CreateUser(t.Context(), testutil.CreateUser())
-		require.NoError(t, err)
-
-		err = app.AvatarStorage.Save(t.Context(), user.ID, domain.Avatar{
-			MimeType: "image/png",
-			Data:     []byte("test"),
-		})
-		require.NoError(t, err)
-
-		resp := app.GET(t, "/api/v1/user/me/settings", WithCookie(app.LoginAs(t, user.ID)))
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-		type settingsResp struct {
-			Name   string
-			Email  string
-			Avatar string
-		}
-		data := ReadJSON[settingsResp](t, resp)
-
-		assert.Equal(t, settingsResp{
-			user.Name,
-			string(user.Email),
-			fmt.Sprintf("%s/user/%s/avatar", prefixApi, string(user.ID)),
-		}, data)
-	})
-
 	t.Run("should return 401 if user is not logged in", func(t *testing.T) {
 		resp := app.GET(t, "/api/v1/user/me/settings")
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)

--- a/backend/app/api/user_test.go
+++ b/backend/app/api/user_test.go
@@ -77,6 +77,134 @@ func Test_ApiUserService_User(t *testing.T) {
 	})
 }
 
+func Test_ApiUserService_GetSettings(t *testing.T) {
+	app := NewTestApp(t)
+
+	t.Run("should return settings with email", func(t *testing.T) {
+		user, err := app.DataStorage.CreateUser(t.Context(), testutil.CreateUser())
+		require.NoError(t, err)
+
+		resp := app.GET(t, "/api/v1/user/me/settings", WithCookie(app.LoginAs(t, user.ID)))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		type settingsResp struct {
+			Name  string
+			Email string
+		}
+		data := ReadJSON[settingsResp](t, resp)
+
+		assert.Equal(t, settingsResp{user.Name, string(user.Email)}, data)
+	})
+
+	t.Run("should return avatar url if avatar exists", func(t *testing.T) {
+		user, err := app.DataStorage.CreateUser(t.Context(), testutil.CreateUser())
+		require.NoError(t, err)
+
+		err = app.AvatarStorage.Save(t.Context(), user.ID, domain.Avatar{
+			MimeType: "image/png",
+			Data:     []byte("test"),
+		})
+		require.NoError(t, err)
+
+		resp := app.GET(t, "/api/v1/user/me/settings", WithCookie(app.LoginAs(t, user.ID)))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		type settingsResp struct {
+			Name   string
+			Email  string
+			Avatar string
+		}
+		data := ReadJSON[settingsResp](t, resp)
+
+		assert.Equal(t, settingsResp{
+			user.Name,
+			string(user.Email),
+			fmt.Sprintf("%s/user/%s/avatar", prefixApi, string(user.ID)),
+		}, data)
+	})
+
+	t.Run("should return 401 if user is not logged in", func(t *testing.T) {
+		resp := app.GET(t, "/api/v1/user/me/settings")
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+func Test_ApiUserService_UpdateSettings(t *testing.T) {
+	app := NewTestApp(t)
+
+	t.Run("should update user name", func(t *testing.T) {
+		user, err := app.DataStorage.CreateUser(t.Context(), testutil.CreateUser())
+		require.NoError(t, err)
+
+		resp := app.PUT(t, "/api/v1/user/me/settings",
+			WithCookie(app.LoginAs(t, user.ID)),
+			WithJSON(map[string]string{"Name": "New Name"}),
+		)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		type settingsResp struct {
+			Name  string
+			Email string
+		}
+		data := ReadJSON[settingsResp](t, resp)
+
+		assert.Equal(t, "New Name", data.Name)
+		assert.Equal(t, string(user.Email), data.Email)
+	})
+
+	t.Run("should return 422 when name is empty", func(t *testing.T) {
+		user, err := app.DataStorage.CreateUser(t.Context(), testutil.CreateUser())
+		require.NoError(t, err)
+
+		resp := app.PUT(t, "/api/v1/user/me/settings",
+			WithCookie(app.LoginAs(t, user.ID)),
+			WithJSON(map[string]string{"Name": ""}),
+		)
+		assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+	})
+
+	t.Run("should return 401 if user is not logged in", func(t *testing.T) {
+		resp := app.PUT(t, "/api/v1/user/me/settings",
+			WithJSON(map[string]string{"Name": "Test"}),
+		)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+func Test_ApiUserService_DeleteAvatar(t *testing.T) {
+	app := NewTestApp(t)
+
+	t.Run("should delete avatar", func(t *testing.T) {
+		user, err := app.DataStorage.CreateUser(t.Context(), testutil.CreateUser())
+		require.NoError(t, err)
+
+		err = app.AvatarStorage.Save(t.Context(), user.ID, domain.Avatar{
+			MimeType: "image/png",
+			Data:     []byte("test"),
+		})
+		require.NoError(t, err)
+
+		resp := app.DELETE(t, "/api/v1/user/me/avatar", WithCookie(app.LoginAs(t, user.ID)))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		exists, err := app.AvatarStorage.Exists(t.Context(), user.ID)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("should succeed even if no avatar exists", func(t *testing.T) {
+		userID := domain.NewUserID()
+
+		resp := app.DELETE(t, "/api/v1/user/me/avatar", WithCookie(app.LoginAs(t, userID)))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("should return 401 if user is not logged in", func(t *testing.T) {
+		resp := app.DELETE(t, "/api/v1/user/me/avatar")
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
 func Test_ApiUserService_MyAvatar(t *testing.T) {
 	app := NewTestApp(t)
 

--- a/backend/app/internal/testutil/user.go
+++ b/backend/app/internal/testutil/user.go
@@ -1,0 +1,18 @@
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/healthy-heroes/neskuchka/backend/app/domain"
+)
+
+func CreateUser() domain.User {
+	id := domain.NewUserID()
+	email := domain.Email(fmt.Sprintf("user-%s@example.com", id))
+
+	return domain.User{
+		ID:    id,
+		Name:  fmt.Sprintf("User #%s", id),
+		Email: email,
+	}
+}

--- a/backend/app/storage/avatarstorage/avatar.go
+++ b/backend/app/storage/avatarstorage/avatar.go
@@ -62,3 +62,12 @@ func (s *Storage) Save(ctx context.Context, id domain.UserID, avatar domain.Avat
 
 	return nil
 }
+
+func (s *Storage) Exists(ctx context.Context, id domain.UserID) (bool, error) {
+	var exists bool
+	err := s.engine.GetContext(ctx, &exists, "SELECT EXISTS(SELECT 1 FROM avatar WHERE user_id = ?)", id)
+	if err != nil {
+		return false, storage.HandleSqlError(err)
+	}
+	return exists, nil
+}

--- a/backend/app/storage/avatarstorage/avatar.go
+++ b/backend/app/storage/avatarstorage/avatar.go
@@ -63,6 +63,11 @@ func (s *Storage) Save(ctx context.Context, id domain.UserID, avatar domain.Avat
 	return nil
 }
 
+func (s *Storage) Delete(ctx context.Context, id domain.UserID) error {
+	_, err := s.engine.ExecContext(ctx, "DELETE FROM avatar WHERE user_id = ?", id)
+	return storage.HandleSqlError(err)
+}
+
 func (s *Storage) Exists(ctx context.Context, id domain.UserID) (bool, error) {
 	var exists bool
 	err := s.engine.GetContext(ctx, &exists, "SELECT EXISTS(SELECT 1 FROM avatar WHERE user_id = ?)", id)

--- a/backend/app/storage/avatarstorage/avatar_test.go
+++ b/backend/app/storage/avatarstorage/avatar_test.go
@@ -27,3 +27,21 @@ func Test_AvatarStorage_SaveAndGet(t *testing.T) {
 	_, err = storage.Get(t.Context(), domain.NewUserID())
 	assert.ErrorIs(t, err, domain.ErrNotFound)
 }
+
+func Test_AvatarStorage_Exists(t *testing.T) {
+	storage := setupTestStorage(t)
+
+	userID := domain.NewUserID()
+	storage.Save(t.Context(), userID, domain.Avatar{
+		MimeType: "image/png",
+		Data:     []byte("test"),
+	})
+
+	exists, err := storage.Exists(t.Context(), userID)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = storage.Exists(t.Context(), domain.NewUserID())
+	require.NoError(t, err)
+	assert.False(t, exists)
+}

--- a/backend/app/storage/avatarstorage/avatar_test.go
+++ b/backend/app/storage/avatarstorage/avatar_test.go
@@ -44,4 +44,10 @@ func Test_AvatarStorage_Exists(t *testing.T) {
 	exists, err = storage.Exists(t.Context(), domain.NewUserID())
 	require.NoError(t, err)
 	assert.False(t, exists)
+
+	err = storage.Delete(t.Context(), userID)
+	require.NoError(t, err)
+	exists, err = storage.Exists(t.Context(), userID)
+	require.NoError(t, err)
+	assert.False(t, exists)
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -35,4 +35,16 @@ export default class ApiClient {
 			.post<TResponse>(`${this.apiPath}/${path}`, payload)
 			.then((response) => response.data);
 	}
+
+	async postForm<TResponse>(path: string, formData: FormData): Promise<TResponse> {
+		return axios
+			.post<TResponse>(`${this.apiPath}/${path}`, formData, {
+				headers: { 'Content-Type': 'multipart/form-data' },
+			})
+			.then((response) => response.data);
+	}
+
+	async delete<TResponse>(path: string): Promise<TResponse> {
+		return axios.delete<TResponse>(`${this.apiPath}/${path}`).then((response) => response.data);
+	}
 }

--- a/frontend/src/api/services/user.ts
+++ b/frontend/src/api/services/user.ts
@@ -1,20 +1,22 @@
-import { UseQueryOptions } from '@tanstack/react-query';
+import { UseMutationOptions, UseQueryOptions } from '@tanstack/react-query';
 import axios from 'axios';
-import { User } from '@/types/domain';
+import { User, UserSettings } from '@/types/domain';
 import Service from './service';
 
 export const UserKeys = {
 	me: ['user', 'me'] as const,
+	settings: ['user', 'settings'] as const,
 };
 
 type UserResponse = {
 	data: User;
 };
 
+type SettingsResponse = {
+	data: UserSettings;
+};
+
 export class UserService extends Service {
-	/**
-	 * Get the current user if authenticated, null if not authenticated (401)
-	 */
 	getUserQuery(): UseQueryOptions<UserResponse | null> {
 		return {
 			queryKey: UserKeys.me,
@@ -28,7 +30,42 @@ export class UserService extends Service {
 					throw error;
 				}
 			},
-			staleTime: 5 * 60 * 1000, // 5 minutes
+			staleTime: 5 * 60 * 1000,
+		};
+	}
+
+	getSettingsQuery(): UseQueryOptions<SettingsResponse, Error, UserSettings> {
+		return {
+			queryKey: UserKeys.settings,
+			queryFn: () => this.api.get<SettingsResponse>(`user/me/settings`),
+			select: (response) => response.data,
+		};
+	}
+
+	updateSettingsMutation(): UseMutationOptions<UserSettings, Error, { Name: string }> {
+		return {
+			mutationFn: async (payload) => {
+				const response = await this.api.put<SettingsResponse>(`user/me/settings`, payload);
+				return response.data;
+			},
+		};
+	}
+
+	uploadAvatarMutation(): UseMutationOptions<unknown, Error, File> {
+		return {
+			mutationFn: async (file) => {
+				const formData = new FormData();
+				formData.append('avatar', file);
+				return this.api.postForm(`user/me/avatar`, formData);
+			},
+		};
+	}
+
+	deleteAvatarMutation(): UseMutationOptions<unknown, Error, void> {
+		return {
+			mutationFn: async () => {
+				return this.api.delete(`user/me/avatar`);
+			},
 		};
 	}
 }

--- a/frontend/src/components/Header/Header.story.tsx
+++ b/frontend/src/components/Header/Header.story.tsx
@@ -26,3 +26,17 @@ export function LoggedIn() {
 		</StoryPreview>
 	);
 }
+
+export function LoggedInWithAvatar() {
+	const apiService = createApiServiceMock({
+		user: createUserServiceMock({
+			user: { ...mockUser, Avatar: '/img/avatar.jpg' },
+		}),
+	});
+
+	return (
+		<StoryPreview apiService={apiService}>
+			<Header />
+		</StoryPreview>
+	);
+}

--- a/frontend/src/components/Header/UserMenu.tsx
+++ b/frontend/src/components/Header/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { IconLogout, IconUser } from '@tabler/icons-react';
+import { IconLogout, IconSettings, IconUser } from '@tabler/icons-react';
 import { ActionIcon, Avatar, Button, Menu, Skeleton } from '@mantine/core';
 import { useAuth } from '@/auth/hooks';
 import { RouteLink } from '../RouteLink/RouteLink';
@@ -25,8 +25,12 @@ export function UserMenu() {
 
 				<Menu.Dropdown>
 					<Menu.Label>{user.Name}</Menu.Label>
-					<Menu.Item leftSection={<IconUser size={16} />} disabled>
-						Профиль
+					<Menu.Item
+						component={RouteLink}
+						to="/settings"
+						leftSection={<IconSettings size={16} />}
+					>
+						Настройки
 					</Menu.Item>
 					<Menu.Divider />
 					<Menu.Item color="red" leftSection={<IconLogout size={16} />} onClick={() => logout()}>

--- a/frontend/src/components/Header/UserMenu.tsx
+++ b/frontend/src/components/Header/UserMenu.tsx
@@ -25,11 +25,7 @@ export function UserMenu() {
 
 				<Menu.Dropdown>
 					<Menu.Label>{user.Name}</Menu.Label>
-					<Menu.Item
-						component={RouteLink}
-						to="/settings"
-						leftSection={<IconSettings size={16} />}
-					>
+					<Menu.Item component={RouteLink} to="/settings" leftSection={<IconSettings size={16} />}>
 						Настройки
 					</Menu.Item>
 					<Menu.Divider />

--- a/frontend/src/components/Header/UserMenu.tsx
+++ b/frontend/src/components/Header/UserMenu.tsx
@@ -1,5 +1,5 @@
 import { IconLogout, IconUser } from '@tabler/icons-react';
-import { ActionIcon, Button, Menu, Skeleton } from '@mantine/core';
+import { ActionIcon, Avatar, Button, Menu, Skeleton } from '@mantine/core';
 import { useAuth } from '@/auth/hooks';
 import { RouteLink } from '../RouteLink/RouteLink';
 
@@ -14,9 +14,13 @@ export function UserMenu() {
 		return (
 			<Menu shadow="md" width={200}>
 				<Menu.Target>
-					<ActionIcon variant="outline" color="blue" size="lg" radius="xl" bd="2px solid">
-						<IconUser size={20} />
-					</ActionIcon>
+					{user.Avatar ? (
+						<Avatar src={user.Avatar} size="md" radius="xl" style={{ cursor: 'pointer' }} />
+					) : (
+						<ActionIcon variant="outline" color="blue" size="lg" radius="xl" bd="2px solid">
+							<IconUser size={20} />
+						</ActionIcon>
+					)}
 				</Menu.Target>
 
 				<Menu.Dropdown>

--- a/frontend/src/pages/Settings/Settings.page.tsx
+++ b/frontend/src/pages/Settings/Settings.page.tsx
@@ -1,0 +1,171 @@
+import { useEffect } from 'react';
+import { IconPhoto, IconTrash, IconUpload } from '@tabler/icons-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+	ActionIcon,
+	Alert,
+	Avatar,
+	Button,
+	Container,
+	FileButton,
+	Group,
+	Stack,
+	Text,
+	TextInput,
+	Title,
+} from '@mantine/core';
+import { isNotEmpty, useForm } from '@mantine/form';
+import { useApi } from '@/api/hooks';
+import { UserKeys } from '@/api/services/user';
+import { Header } from '@/components/Header/Header';
+import { PageSkeleton } from '@/components/PageSkeleton/PageSkeleton';
+
+interface SettingsFormData {
+	Name: string;
+}
+
+export function SettingsPage() {
+	const queryClient = useQueryClient();
+	const { user } = useApi();
+
+	const { data: settings, isPending } = useQuery(user.getSettingsQuery());
+
+	const invalidateUserData = () => {
+		queryClient.invalidateQueries({ queryKey: UserKeys.me });
+		queryClient.invalidateQueries({ queryKey: UserKeys.settings });
+	};
+
+	const updateSettings = useMutation({
+		...user.updateSettingsMutation(),
+		onSuccess: invalidateUserData,
+	});
+	const uploadAvatar = useMutation({
+		...user.uploadAvatarMutation(),
+		onSuccess: invalidateUserData,
+	});
+	const deleteAvatar = useMutation({
+		...user.deleteAvatarMutation(),
+		onSuccess: invalidateUserData,
+	});
+
+	const form = useForm<SettingsFormData>({
+		mode: 'uncontrolled',
+		initialValues: { Name: '' },
+		validate: {
+			Name: isNotEmpty('Имя не может быть пустым'),
+		},
+		enhanceGetInputProps: () => ({
+			disabled: updateSettings.isPending,
+		}),
+	});
+
+	useEffect(() => {
+		if (settings) {
+			form.initialize({ Name: settings.Name });
+		}
+	}, [settings]); // eslint-disable-line react-hooks/exhaustive-deps
+
+	if (isPending) {
+		return <PageSkeleton />;
+	}
+
+	if (!settings) {
+		return null;
+	}
+
+	function handleSubmit(values: SettingsFormData) {
+		updateSettings.mutate({ Name: values.Name });
+	}
+
+	function handleAvatarUpload(file: File | null) {
+		if (file) {
+			uploadAvatar.mutate(file);
+		}
+	}
+
+	function handleAvatarDelete() {
+		deleteAvatar.mutate();
+	}
+
+	return (
+		<>
+			<Header />
+			<Container size="xs" py="xl">
+				<Title order={2} mb="lg">
+					Настройки
+				</Title>
+
+				<Stack gap="xl">
+					<Stack gap="sm">
+						<Text fw={500}>Аватар</Text>
+						<Group>
+							<Avatar src={settings.Avatar} size={80} radius="xl">
+								<IconPhoto size={32} />
+							</Avatar>
+							<Stack gap="xs">
+								<FileButton onChange={handleAvatarUpload} accept="image/png,image/jpeg,image/webp">
+									{(props) => (
+										<Button
+											{...props}
+											variant="light"
+											size="xs"
+											leftSection={<IconUpload size={14} />}
+											loading={uploadAvatar.isPending}
+										>
+											Загрузить
+										</Button>
+									)}
+								</FileButton>
+								{settings.Avatar && (
+									<ActionIcon
+										variant="subtle"
+										color="red"
+										size="sm"
+										onClick={handleAvatarDelete}
+										loading={deleteAvatar.isPending}
+										title="Удалить аватар"
+									>
+										<IconTrash size={14} />
+									</ActionIcon>
+								)}
+							</Stack>
+						</Group>
+						{uploadAvatar.isError && (
+							<Alert color="red" variant="light">
+								Не удалось загрузить аватар
+							</Alert>
+						)}
+					</Stack>
+
+					<form onSubmit={form.onSubmit(handleSubmit)}>
+						<Stack gap="md">
+							<TextInput
+								label="Email"
+								value={settings.Email}
+								readOnly
+								variant="filled"
+							/>
+							<TextInput
+								label="Имя"
+								key={form.key('Name')}
+								{...form.getInputProps('Name')}
+							/>
+
+							{updateSettings.isError && (
+								<Alert color="red" variant="light">
+									Не удалось сохранить изменения
+								</Alert>
+							)}
+
+							<Group>
+								<Button type="submit" loading={updateSettings.isPending}>
+									Сохранить
+								</Button>
+							</Group>
+						</Stack>
+					</form>
+				</Stack>
+			</Container>
+		</>
+	);
+}

--- a/frontend/src/pages/Settings/Settings.page.tsx
+++ b/frontend/src/pages/Settings/Settings.page.tsx
@@ -63,7 +63,7 @@ export function SettingsPage() {
 		if (settings) {
 			form.initialize({ Name: settings.Name });
 		}
-	}, [settings]); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [settings]);
 
 	if (isPending) {
 		return <PageSkeleton />;

--- a/frontend/src/pages/Settings/Settings.page.tsx
+++ b/frontend/src/pages/Settings/Settings.page.tsx
@@ -1,18 +1,17 @@
-import { useEffect } from 'react';
-import { IconPhoto, IconTrash, IconUpload } from '@tabler/icons-react';
+import { useEffect, useRef } from 'react';
+import { IconPencil, IconPhoto, IconTrash } from '@tabler/icons-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
-	ActionIcon,
 	Alert,
 	Avatar,
 	Button,
 	Container,
-	FileButton,
 	Group,
+	Menu,
+	Paper,
 	Stack,
 	Text,
 	TextInput,
-	Title,
 } from '@mantine/core';
 import { isNotEmpty, useForm } from '@mantine/form';
 import { useApi } from '@/api/hooks';
@@ -27,6 +26,7 @@ interface SettingsFormData {
 export function SettingsPage() {
 	const queryClient = useQueryClient();
 	const { user } = useApi();
+	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	const { data: settings, isPending } = useQuery(user.getSettingsQuery());
 
@@ -77,93 +77,106 @@ export function SettingsPage() {
 		updateSettings.mutate({ Name: values.Name });
 	}
 
-	function handleAvatarUpload(file: File | null) {
+	function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+		const file = e.target.files?.[0];
 		if (file) {
 			uploadAvatar.mutate(file);
 		}
-	}
-
-	function handleAvatarDelete() {
-		deleteAvatar.mutate();
+		e.target.value = '';
 	}
 
 	return (
 		<>
 			<Header />
 			<Container size="xs" py="xl">
-				<Title order={2} mb="lg">
-					Настройки
-				</Title>
-
-				<Stack gap="xl">
-					<Stack gap="sm">
-						<Text fw={500}>Аватар</Text>
-						<Group>
-							<Avatar src={settings.Avatar} size={80} radius="xl">
-								<IconPhoto size={32} />
+				<Stack gap="lg">
+					<Paper radius="md" withBorder p="xl">
+						<Stack align="center" gap="md">
+							<Avatar src={settings.Avatar} size={180} radius={180}>
+								{settings.Name.charAt(0).toUpperCase()}
 							</Avatar>
-							<Stack gap="xs">
-								<FileButton onChange={handleAvatarUpload} accept="image/png,image/jpeg,image/webp">
-									{(props) => (
-										<Button
-											{...props}
-											variant="light"
-											size="xs"
-											leftSection={<IconUpload size={14} />}
-											loading={uploadAvatar.isPending}
-										>
-											Загрузить
-										</Button>
-									)}
-								</FileButton>
-								{settings.Avatar && (
-									<ActionIcon
-										variant="subtle"
-										color="red"
-										size="sm"
-										onClick={handleAvatarDelete}
-										loading={deleteAvatar.isPending}
-										title="Удалить аватар"
+
+							<input
+								ref={fileInputRef}
+								type="file"
+								accept="image/png,image/jpeg,image/webp"
+								onChange={handleFileChange}
+								hidden
+							/>
+
+							<Menu shadow="md" width={200} position="bottom">
+								<Menu.Target>
+									<Button
+										variant="default"
+										size="xs"
+										leftSection={<IconPencil size={14} />}
+										loading={uploadAvatar.isPending || deleteAvatar.isPending}
 									>
-										<IconTrash size={14} />
-									</ActionIcon>
-								)}
-							</Stack>
-						</Group>
-						{uploadAvatar.isError && (
-							<Alert color="red" variant="light">
-								Не удалось загрузить аватар
-							</Alert>
-						)}
-					</Stack>
+										Редактировать
+									</Button>
+								</Menu.Target>
+								<Menu.Dropdown>
+									<Menu.Item
+										leftSection={<IconPhoto size={16} />}
+										onClick={() => fileInputRef.current?.click()}
+									>
+										Загрузить фото...
+									</Menu.Item>
+									{settings.Avatar && (
+										<Menu.Item
+											color="red"
+											leftSection={<IconTrash size={16} />}
+											onClick={() => deleteAvatar.mutate()}
+										>
+											Удалить фото
+										</Menu.Item>
+									)}
+								</Menu.Dropdown>
+							</Menu>
 
-					<form onSubmit={form.onSubmit(handleSubmit)}>
-						<Stack gap="md">
-							<TextInput
-								label="Email"
-								value={settings.Email}
-								readOnly
-								variant="filled"
-							/>
-							<TextInput
-								label="Имя"
-								key={form.key('Name')}
-								{...form.getInputProps('Name')}
-							/>
-
-							{updateSettings.isError && (
-								<Alert color="red" variant="light">
-									Не удалось сохранить изменения
+							{uploadAvatar.isError && (
+								<Alert color="red" variant="light" w="100%">
+									Не удалось загрузить аватар
 								</Alert>
 							)}
-
-							<Group>
-								<Button type="submit" loading={updateSettings.isPending}>
-									Сохранить
-								</Button>
-							</Group>
 						</Stack>
-					</form>
+					</Paper>
+
+					<Paper radius="md" withBorder p="xl">
+						<form onSubmit={form.onSubmit(handleSubmit)}>
+							<Stack gap="md">
+								<Text fw={600} size="lg">
+									Личные данные
+								</Text>
+
+								<TextInput
+									label="Email"
+									value={settings.Email}
+									readOnly
+									variant="filled"
+									description="Email нельзя изменить"
+								/>
+								<TextInput
+									label="Имя"
+									placeholder="Ваше имя"
+									key={form.key('Name')}
+									{...form.getInputProps('Name')}
+								/>
+
+								{updateSettings.isError && (
+									<Alert color="red" variant="light">
+										Не удалось сохранить изменения
+									</Alert>
+								)}
+
+								<Group justify="flex-end">
+									<Button type="submit" loading={updateSettings.isPending}>
+										Сохранить
+									</Button>
+								</Group>
+							</Stack>
+						</form>
+					</Paper>
 				</Stack>
 			</Container>
 		</>

--- a/frontend/src/pages/Settings/Settings.page.tsx
+++ b/frontend/src/pages/Settings/Settings.page.tsx
@@ -16,6 +16,7 @@ import {
 import { isNotEmpty, useForm } from '@mantine/form';
 import { useApi } from '@/api/hooks';
 import { UserKeys } from '@/api/services/user';
+import { useAuth } from '@/auth/hooks';
 import { Header } from '@/components/Header/Header';
 import { PageSkeleton } from '@/components/PageSkeleton/PageSkeleton';
 
@@ -25,6 +26,7 @@ interface SettingsFormData {
 
 export function SettingsPage() {
 	const queryClient = useQueryClient();
+	const { user: authUser } = useAuth();
 	const { user } = useApi();
 	const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -92,7 +94,7 @@ export function SettingsPage() {
 				<Stack gap="lg">
 					<Paper radius="md" withBorder p="xl">
 						<Stack align="center" gap="md">
-							<Avatar src={settings.Avatar} size={180} radius={180}>
+							<Avatar src={authUser?.Avatar} size={180} radius={180}>
 								{settings.Name.charAt(0).toUpperCase()}
 							</Avatar>
 
@@ -122,7 +124,7 @@ export function SettingsPage() {
 									>
 										Загрузить фото...
 									</Menu.Item>
-									{settings.Avatar && (
+									{authUser?.Avatar && (
 										<Menu.Item
 											color="red"
 											leftSection={<IconTrash size={16} />}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WorkoutsRouteImport } from './routes/workouts'
 import { Route as WelcomeRouteImport } from './routes/welcome'
+import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkoutsIndexRouteImport } from './routes/workouts.index'
@@ -28,6 +29,11 @@ const WorkoutsRoute = WorkoutsRouteImport.update({
 const WelcomeRoute = WelcomeRouteImport.update({
   id: '/welcome',
   path: '/welcome',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsRoute = SettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -74,6 +80,7 @@ const WorkoutsWorkoutIdEditRoute = WorkoutsWorkoutIdEditRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRouteWithChildren
+  '/settings': typeof SettingsRoute
   '/welcome': typeof WelcomeRoute
   '/workouts': typeof WorkoutsRouteWithChildren
   '/login/confirm': typeof LoginConfirmRoute
@@ -85,6 +92,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/settings': typeof SettingsRoute
   '/welcome': typeof WelcomeRoute
   '/login/confirm': typeof LoginConfirmRoute
   '/workouts/$workoutId': typeof WorkoutsWorkoutIdRoute
@@ -97,6 +105,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/login': typeof LoginRouteWithChildren
+  '/settings': typeof SettingsRoute
   '/welcome': typeof WelcomeRoute
   '/workouts': typeof WorkoutsRouteWithChildren
   '/login/confirm': typeof LoginConfirmRoute
@@ -111,6 +120,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/login'
+    | '/settings'
     | '/welcome'
     | '/workouts'
     | '/login/confirm'
@@ -122,6 +132,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/settings'
     | '/welcome'
     | '/login/confirm'
     | '/workouts/$workoutId'
@@ -133,6 +144,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/login'
+    | '/settings'
     | '/welcome'
     | '/workouts'
     | '/login/confirm'
@@ -146,6 +158,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRouteWithChildren
+  SettingsRoute: typeof SettingsRoute
   WelcomeRoute: typeof WelcomeRoute
   WorkoutsRoute: typeof WorkoutsRouteWithChildren
 }
@@ -164,6 +177,13 @@ declare module '@tanstack/react-router' {
       path: '/welcome'
       fullPath: '/welcome'
       preLoaderRoute: typeof WelcomeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -258,6 +278,7 @@ const WorkoutsRouteWithChildren = WorkoutsRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRouteWithChildren,
+  SettingsRoute: SettingsRoute,
   WelcomeRoute: WelcomeRoute,
   WorkoutsRoute: WorkoutsRouteWithChildren,
 }

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { RequireAuth } from '@/auth/RequireAuth';
+import { PageSkeleton } from '@/components/PageSkeleton/PageSkeleton';
+import { SettingsPage } from '@/pages/Settings/Settings.page';
+
+export const Route = createFileRoute('/settings')({
+	component: () => (
+		<RequireAuth loadingComponent={<PageSkeleton />}>
+			<SettingsPage />
+		</RequireAuth>
+	),
+});

--- a/frontend/src/types/domain.ts
+++ b/frontend/src/types/domain.ts
@@ -4,6 +4,12 @@ export interface User {
 	Avatar?: string;
 }
 
+export interface UserSettings {
+	Name: string;
+	Email: string;
+	Avatar?: string;
+}
+
 export interface Track {
 	ID: string;
 	Name: string;

--- a/frontend/src/types/domain.ts
+++ b/frontend/src/types/domain.ts
@@ -7,7 +7,6 @@ export interface User {
 export interface UserSettings {
 	Name: string;
 	Email: string;
-	Avatar?: string;
 }
 
 export interface Track {

--- a/frontend/src/types/domain.ts
+++ b/frontend/src/types/domain.ts
@@ -1,6 +1,7 @@
 export interface User {
 	ID: string;
 	Name: string;
+	Avatar?: string;
 }
 
 export interface Track {


### PR DESCRIPTION
## Summary

- Add `/settings` page with avatar management (upload, delete via dropdown menu) and name editing
- Add backend endpoints: `GET/PUT /user/me/settings` and `DELETE /user/me/avatar`
- Show user avatar in the header menu

## Test plan

- [ ] Verify settings page loads at `/settings` for authenticated users
- [ ] Upload, change, and remove avatar — check it updates in header and settings
- [ ] Edit display name and verify it persists
- [ ] Verify unauthenticated users are redirected away from `/settings`
- [ ] Run backend tests (`mise run //backend:tests`)


Made with [Cursor](https://cursor.com)