### PR TITLE
Implement idempotency in user creation and update CreateUser method

### DIFF
--- a/backend/app/storage/datastorage/user.go
+++ b/backend/app/storage/datastorage/user.go
@@ -49,17 +49,22 @@ func (s *Storage) GetUserByEmail(ctx context.Context, email domain.Email) (domai
 	return u.toDomain(), storage.HandleSqlError(err)
 }
 
+// CreateUser creates a new user
+// no failure if user already exists
+// returns the created user or the existing one
 func (s *Storage) CreateUser(ctx context.Context, user domain.User) (domain.User, error) {
 	u := makeUser(user)
 
-	_, err := s.engine.ExecContext(ctx, "INSERT INTO user(id, email, name) VALUES(?,?,?)",
+	_, err := s.engine.ExecContext(ctx,
+		`INSERT INTO user(id, email, name) VALUES(?,?,?)
+		ON CONFLICT(email) DO NOTHING`,
 		u.ID, u.Email, u.Name)
 
 	if err != nil {
 		return domain.User{}, storage.HandleSqlError(err)
 	}
 
-	return s.GetUser(ctx, user.ID)
+	return s.GetUserByEmail(ctx, user.Email)
 }
 
 func (s *Storage) UpdateUser(ctx context.Context, user domain.User) (domain.User, error) {

--- a/backend/app/storage/datastorage/user_test.go
+++ b/backend/app/storage/datastorage/user_test.go
@@ -39,6 +39,16 @@ func Test_User_Create(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, newUser, userByEmail)
 
+	// checks idempotency
+	newUser2 := domain.User{
+		ID:    domain.NewUserID(),
+		Name:  "Test User 2",
+		Email: "test@example.com",
+	}
+	createdUser2, err := ds.CreateUser(t.Context(), newUser2)
+	require.NoError(t, err)
+	assert.Equal(t, createdUser, createdUser2)
+
 	// checks system fields
 	createdRow := userFromDB(t, ds.engine, string(createdUser.ID))
 	assert.NotZero(t, createdRow.CreatedAt)


### PR DESCRIPTION
- Modify CreateUser to handle existing users by using ON CONFLICT in SQL.
- Update tests to verify that creating a user with an existing email returns the same user.
- Ensure that the method now retrieves the user by email instead of ID after creation.