### PR TITLE
Drop git hooks, make checks and tests fast and quiet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,6 @@ jobs:
 
       - name: tests
         run: mise run //frontend:tests
+
+      - name: build
+        run: mise run //frontend:build

--- a/.mise.toml
+++ b/.mise.toml
@@ -24,6 +24,7 @@ flag "--fix" {
     help "Enable automatic fixes"
 }
 '''
+quiet = true
 run = [
     "mise run //backend:checks ${usage_fix:+--fix}",
     "mise run //frontend:checks ${usage_fix:+--fix}",
@@ -36,15 +37,10 @@ run = [
     { task = "//frontend:tests" },
 ]
 
-[tasks.pre-commit]
-description = "Pre-commit hook"
-run = [
-    { task = "checks" },
-]
-
-[tasks.pre-push]
-description = "Pre-push hook"
+[tasks.ci]
+description = "Run everything: linters, tests, frontend build"
 run = [
     { task = "checks" },
     { task = "tests" },
+    { task = "//frontend:build" },
 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,16 @@ cd frontend && mise run checks # то же самое из подкаталог�
 ```
 
 Прочее: `//backend:seed` (пересоздаёт `bin/app.db`), `//backend:token`, `//backend:coverage`,
-`//frontend:app` (`--back` — прокси на локальный бэкенд), `//frontend:storybook`.
+`//frontend:app` (`--back` — прокси на локальный бэкенд), `//frontend:build`,
+`//frontend:storybook`.
 
-Pre-commit хук гоняет `checks`, pre-push — `checks` + `tests`.
+Git-хуков нет — коммит и пуш ничего не гоняют. Всё вместе (`checks` + `tests` +
+`//frontend:build`) запускает `mise run ci`; это команда для человека перед пушем.
+
+При работе гоняй точечно то, что затронул, а не `ci` целиком: `//backend:tests`,
+`//frontend:tests`, `//frontend:checks`. Задачи молчат, пока всё зелёное — пустой вывод
+и нулевой exit code означают успех, при падении печатается полный лог. Покрытие в обычный
+прогон тестов не входит, для него есть `//backend:coverage`.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -23,23 +23,21 @@ mise trust --all
 mise settings experimental=true
 ```
 
-Настраиваем git-хуки:
-```
-## pre commit hook
-mise generate git-pre-commit --write --task=pre-commit
-
-## pre push hook
-mise generate git-pre-commit --write --task=pre-push --hook=pre-push
-```
-
 **Для Windows**
 Для разработки рекомендуется использовать WSL 2, а для запуска docker-compose должна быть включена [интеграция с WSL](https://docs.docker.com/desktop/features/wsl/)
 
 ### Запуск линтеров и тестов
 Для запуска линтеров и тестов используется mise. Запускать можно в проекте или в корневом каталоге.
 
+- `ci` - линтеры + тесты + сборка фронтенда, одной командой перед пушем
 - `checks` - запуск линтеров, поддерживает флаг `--fix` для автоматического исправления ошибок
 - `tests` - запуск тестов
+
+Git-хуков нет: проверки не навешаны на коммит и пуш, гоняем их руками через `mise run ci`.
+
+Задачи `checks`, `tests` и `//frontend:build` молчат, пока всё зелёное — вывод появляется
+только когда что-то упало. Покрытие бэкенда считает отдельная задача `//backend:coverage`,
+в обычный прогон тестов оно не входит.
 
 При запуске из корня испольузется фича `experimental_monorepo_root`, позволяет удобно запускать задачи из любого проекта:
 ```
@@ -57,6 +55,9 @@ mise run //frontend:checks --fix
 
 ## запуск тестов фронтенда
 mise run //frontend:tests
+
+## всё сразу перед пушем
+mise run ci
 ```
 
 ### Запуск локального сервера

--- a/backend/.mise.toml
+++ b/backend/.mise.toml
@@ -29,14 +29,20 @@ flag "--fix" {
     help "Enable automatic fixes"
 }
 '''
+quiet = true
 run = '''
-set -x
-golangci-lint run --config .golangci.yml ./... ${usage_fix:+--fix}
+golangci-lint run --config .golangci.yml --show-stats=false ./... ${usage_fix:+--fix}
 '''
 
 [tasks.tests]
-description = "Run tests"
-run = "go test -cover ./... -coverpkg=./..."
+description = "Run tests, silent unless something fails"
+quiet = true
+run = '''
+if ! output=$(go test ./... 2>&1); then
+    printf '%s\n' "$output"
+    exit 1
+fi
+'''
 
 [tasks.coverage]
 description = "Run coverage"

--- a/frontend/.mise.toml
+++ b/frontend/.mise.toml
@@ -38,23 +38,36 @@ flag "--fix" {
     help "Enable automatic fixes"
 }
 '''
+quiet = true
 run = """
-set -x
-pnpm run typecheck
+pnpm -s run typecheck
 if [ "$usage_fix" = "true" ]; then
-    pnpm run prettier:write
-    pnpm run eslint:fix
-    pnpm run stylelint:fix
+    pnpm -s run prettier:write
+    pnpm -s run eslint:fix
+    pnpm -s run stylelint:fix
 else
-    pnpm run prettier
-    pnpm run eslint
-    pnpm run stylelint
+    pnpm -s run prettier
+    pnpm -s run eslint
+    pnpm -s run stylelint
 fi
 """
 
 [tasks.tests]
-description = "Run tests"
-run = [
-    "pnpm run vitest",
-    "pnpm run build",
-]
+description = "Run tests, silent unless something fails"
+quiet = true
+run = '''
+if ! output=$(NODE_NO_WARNINGS=1 pnpm -s run vitest 2>&1); then
+    printf '%s\n' "$output"
+    exit 1
+fi
+'''
+
+[tasks.build]
+description = "Build the application, silent unless the build fails"
+quiet = true
+run = '''
+if ! output=$(pnpm -s run build 2>&1); then
+    printf '%s\n' "$output"
+    exit 1
+fi
+'''

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "eslint:fix": "eslint . --fix --cache",
     "stylelint": "stylelint '**/*.css' --cache",
     "stylelint:fix": "stylelint '**/*.css' --fix --cache",
-    "prettier": "prettier --check \"**/*.{ts,tsx}\"",
+    "prettier": "prettier --check --log-level warn \"**/*.{ts,tsx}\"",
     "prettier:write": "prettier --write \"**/*.{ts,tsx}\"",
     "vitest": "vitest run",
     "vitest:watch": "vitest",


### PR DESCRIPTION
Хуки гоняли `checks` на каждый коммит и `checks` + `tests` на каждый пуш, и любой прогон печатал полный лог, даже когда всё зелёное. Заменяем это одной явной командой.

## Что сделано

- Удалены хуки `pre-commit` / `pre-push` и одноимённые mise-задачи. Вместо них — `mise run ci` (`checks` + `tests` + `//frontend:build`), запускать руками перед пушем.
- Из `//backend:tests` убраны `-cover -coverpkg=./...`. Покрытие осталось в отдельной задаче `//backend:coverage`.
- `pnpm run build` вынесен из `//frontend:tests` в отдельную задачу `//frontend:build`; в `ci.yml` добавлен соответствующий шаг, чтобы проверка сборки не потерялась.
- Задачи молчат, пока всё зелёное, и печатают полный лог при падении. Убраны `set -x`, баннеры pnpm, эхо команд mise, статистика golangci-lint и болтовня prettier.

## Тайминги

| | было | стало |
|---|---|---|
| `//backend:tests`, холодный | 10.2s | 7.0s |
| `//backend:tests`, тёплый | 0.98s | 0.3s |
| `//frontend:tests` | 5.8s | 2.5s |
| `mise run ci`, вывод при успехе | — | 0 строк |

## Проверки

Прогнаны оба пути для каждой задачи — временные файлы созданы, проверены и удалены:

- падающий Go-тест → полный лог + exit 1
- падающий vitest → полный diff + exit 1
- неформатированный `.ts` → `[warn] src/...` + exit 1
- неиспользуемая функция в Go → сообщение линтера + exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)