### PR TITLE
Return 404 for a missing main track, drop a Cyrillic type name

### DIFF
--- a/backend/app/api/auth/login.go
+++ b/backend/app/api/auth/login.go
@@ -17,8 +17,8 @@ const (
 	confTokenTtlDuration = 30 * time.Minute
 )
 
-// сonfirmationClaims is the claims for confirmation token
-type сonfirmationClaims struct {
+// confirmationClaims is the claims for confirmation token
+type confirmationClaims struct {
 	jwt.RegisteredClaims
 
 	Data LoginSchema `json:"data"`
@@ -39,7 +39,7 @@ func (s *Service) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	claims := сonfirmationClaims{
+	claims := confirmationClaims{
 		Data: loginData,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(confTokenTtlDuration)),
@@ -80,7 +80,7 @@ func (s *Service) Confirm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var confClaims сonfirmationClaims
+	var confClaims confirmationClaims
 	err := s.tokenService.Parse(data.Token, &confClaims)
 	if err != nil {
 		httpx.RenderError(w, logger, http.StatusBadRequest, err, "Failed to parse token")

--- a/backend/app/api/tracks/trackmain.go
+++ b/backend/app/api/tracks/trackmain.go
@@ -15,7 +15,7 @@ func (s *Service) GetMainTrack(w http.ResponseWriter, r *http.Request) {
 
 	track, err := s.dataStore.GetMainTrack(r.Context())
 	if err != nil {
-		httpx.RenderError(w, logger, http.StatusInternalServerError, err, "Failed to get main track")
+		httpx.RenderDomainError(w, logger, err, "Failed to get main track")
 		return
 	}
 
@@ -39,7 +39,7 @@ func (s *Service) GetMainTrackLastWorkouts(w http.ResponseWriter, r *http.Reques
 
 	track, err := s.dataStore.GetMainTrack(r.Context())
 	if err != nil {
-		httpx.RenderError(w, logger, http.StatusInternalServerError, err, "Failed to get main track")
+		httpx.RenderDomainError(w, logger, err, "Failed to get main track")
 		return
 	}
 

--- a/backend/app/api/tracks_test.go
+++ b/backend/app/api/tracks_test.go
@@ -140,6 +140,13 @@ func Test_ApiTracks_GetMainTrack(t *testing.T) {
 		data := ReadJSON[trackResp](t, resp)
 		assert.False(t, data.IsOwner)
 	})
+
+	t.Run("should return 404 when the main track is missing", func(t *testing.T) {
+		app := NewTestApp(t)
+
+		resp := app.GET(t, "/api/v1/tracks/main")
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
 }
 
 func Test_ApiTracks_GetMainTrackLastWorkouts(t *testing.T) {
@@ -207,6 +214,13 @@ func Test_ApiTracks_GetMainTrackLastWorkouts(t *testing.T) {
 		data := ReadJSON[workoutsRespWrapper](t, resp)
 		require.Len(t, data.Workouts, 1)
 		assert.Equal(t, "mine", data.Workouts[0].Notes)
+	})
+
+	t.Run("should return 404 when the main track is missing", func(t *testing.T) {
+		app := NewTestApp(t)
+
+		resp := app.GET(t, "/api/v1/tracks/main/last_workouts")
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	})
 }
 

--- a/backend/app/cmd/dev/seed.go
+++ b/backend/app/cmd/dev/seed.go
@@ -156,7 +156,10 @@ func section(title, protocol, note string, exercises ...domain.WorkoutExercise) 
 
 // seedWorkouts builds three weeks of workouts, three per week, counted back from today.
 // Dates are relative on purpose: the track page puts today's workout in focus, so the
-// seed has to produce one whenever it is run.
+// seed has to produce one whenever it is run. They are stored absolute, so the newest
+// workout stops being today's overnight — the track page falls back to the latest one
+// and the heading switches to "Последняя тренировка". Run `mise run //backend:seed`
+// to get the today state back; it drops the database and seeds it again.
 //
 // Content is taken from the Нескучный спорт telegram channel. There a session is split
 // across two posts — [РАЗМИНКА] and [ТРЕНИРОВКА ДНЯ] minutes apart — and both become


### PR DESCRIPTION
Three small backend items off the backlog, unrelated to each other beyond being cheap.

## A missing main track answered 500

`GetMainTrack` and `GetMainTrackLastWorkouts` rendered every storage failure through
`RenderError` with a hardcoded 500, so `domain.ErrNotFound` came back as a server
error. `GetWorkout` makes the very same `GetMainTrack` call and already mapped it to
404 through `RenderDomainError` — the two handlers disagreed about the same failure.
Both now go through `RenderDomainError`.

Written test-first: the two new cases failed at 500 against the expected 404 before
the fix, with `error: "not found"` in the log confirming they failed on the bug and
not on setup.

## The confirmation claims type was spelled with a Cyrillic `с`

`сonfirmationClaims` in `api/auth/login.go` opened with U+0441, not the Latin letter.
It compiled and linted clean, but `grep confirmationClaims` never found it — which is
how it survived this long. Renamed; the file is now pure ASCII apart from the user
facing `"Вход в Нескучку"`.

## The seed's today workout goes stale overnight

Looked into it and left the code alone: nothing actually breaks. `Workouts.tsx` does
`published.find(isToday) ?? published[0]`, so the page falls back to the latest
workout and `FeaturedWorkout` switches its heading to «Последняя тренировка». What
was worth fixing is the comment above `seedWorkouts`, which claimed the dates are
"relative on purpose" while they are stored absolute — that is precisely why the
today state expires. It now says what happens and that reseeding is the cure.

## Verification

`mise run //backend:checks` and `mise run //backend:tests` are both green. The
frontend is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)